### PR TITLE
fix gem package build for ON 5.0.2 (2016-08-30) (el7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ To generate Packages.gz install dpkg-dev in Debian:
 ~~~
 oneadmin        ALL= (ALL)      NOPASSWD:       /usr/bin/yum install *
 oneadmin        ALL= (ALL)      NOPASSWD:       /usr/bin/apt-get install *
-oneadmin        ALL= (ALL)      NOPASSWD:       /usr/bin/gem install fpm mini_portile
-oneadmin        ALL= (ALL)      NOPASSWD:       /usr/bin/gem install fpm mini_portile2\:2.0.0.rc2
+oneadmin        ALL= (ALL)      NOPASSWD:       /usr/bin/gem install fpm mini_portile2 pkg-config
 ~~~
 
 * Set `install_gems` path in `gem_packages.py` if it is needed:

--- a/gem_packages.py
+++ b/gem_packages.py
@@ -49,7 +49,7 @@ def main(argv):
             print 'Required sudo conf:'
             print '    <user>        ALL= (ALL)      NOPASSWD:       /usr/bin/yum install *'
             print '    <user>        ALL= (ALL)      NOPASSWD:       /usr/bin/apt-get install *'
-            print '    <user>        ALL= (ALL)      NOPASSWD:       /usr/bin/gem install fpm mini_portile2:2.0.0.rc2'
+            print '    <user>        ALL= (ALL)      NOPASSWD:       /usr/bin/gem install fpm mini_portile2 pkg-config'
             print ''
             print 'Usage:'
             print '    gem_packages.py [OPTIONS]'
@@ -100,7 +100,7 @@ def install_packages(release):
     command = "sudo %s install -y %s" % (pkg_manager, pkg_fpm)
     output = execute_cmd(command)
     print "Intalling fpm gem."
-    command = "sudo gem install fpm mini_portile2:2.0.0.rc2"
+    command = "sudo gem install fpm mini_portile2 pkg-config"
     output = execute_cmd(command)
     print "Installing required packages to compile new gems."
     command = "%s --showallpackages" % install_gems_path


### PR DESCRIPTION
Also fpm seems to be broken now when Summary in rpm spec file is empty
Therefore I also needed to do:
```
fpm --rpm-summary polyglot --debug-workspace --log debug --prefix /usr/share/gems -p /var/lib/one/addon-installgems/gems_dir -s gem -x doc -x build_info -t rpm /var/lib/one/addon-installgems/gems_dir/cache/polyglot-0.3.5.gem
```
Further I needed to patch install_gems because thin version is too new for el7:
```
--- /usr/share/one/install_gems	2016-07-22 15:45:29.000000000 +0000
+++ /tmp/install_gems	2016-08-31 11:11:34.857323396 +0000
@@ -23,8 +23,10 @@ end
 
 if !defined?(RUBY_VERSION) || RUBY_VERSION < '2.2.0'
     RACK = 'rack --version "< 2.0.0"'
+    THIN = 'thin --version "< 1.7.0"'
 else
     RACK = 'rack'
+    THIN = 'thin'
 end
 
 TREETOP = 'treetop --version ">= 1.6.3"'
@@ -32,9 +34,9 @@ DEFAULT = DEFAULT_PRE if !defined?(DEFAU
 
 GROUPS={
     :quota      => [SQLITE, 'sequel'],
-    :sunstone   => [RACK, 'sinatra', 'thin', 'memcache-client',
+    :sunstone   => [RACK, 'sinatra', THIN, 'memcache-client',
                      ZENDESK_API, SQLITE],
-    :cloud      => %w{amazon-ec2 sinatra thin uuidtools curb} << RACK,
+    :cloud      => ['amazon-ec2', RACK, 'sinatra', THIN, 'uuidtools', 'curb'],
     :hybrid     => %w{configparser azure},
     :auth_ldap  => LDAP,
     :vmware     => %w{builder trollop},
@@ -62,7 +64,7 @@ DISTRIBUTIONS={
             'curb'      => ['gcc', 'libcurl4-openssl-dev'],
             $nokogiri   => %w{gcc rake libxml2-dev libxslt1-dev patch},
             'xmlparser' => ['gcc', 'libexpat1-dev'],
-            'thin'      => ['g++'],
+            THIN      => ['g++'],
             'json'      => ['gcc']
         },
         :install_command => 'apt-get install',
@@ -79,7 +81,7 @@ DISTRIBUTIONS={
             'curb'      => ['gcc', 'curl-devel'],
             $nokogiri   => %w{gcc rubygem-rake libxml2-devel libxslt-devel patch},
             'xmlparser' => ['gcc', 'expat-devel'],
-            'thin'      => ['gcc-c++'],
+            THIN      => ['gcc-c++'],
             'json'      => ['gcc']
         },
         :install_command => 'yum install'
```