### PR TITLE
Fix ruby gem dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ exclude_gems = ['sinatra', 'rack']
 ~~~
 gem_packages.py
 ~~~
-* The New deb/rpm packages will be available into gems_dir directory.
+* The New deb/rpm packages will be available into ~/.gem/ruby/ directory.
 
 * Extra info:
 ~~~

--- a/gem_packages.py
+++ b/gem_packages.py
@@ -18,9 +18,10 @@ import shutil
 import StringIO
 from subprocess import Popen, PIPE
 from distutils.version import LooseVersion, StrictVersion
+from os.path import expanduser
 
 install_gems_path = "/usr/share/one/install_gems"
-gems_dir = '/var/lib/one/.gem/ruby'
+gems_dir = '.gem/ruby'
 exclude_gems = []
 
 
@@ -113,7 +114,7 @@ def install_packages(release):
 
 def generate_gems():
     global gems_dir
-    path = os.getcwd()
+    path = expanduser("~")
     gems_dir = os.path.join(path, gems_dir)
     if purge:
         shutil.rmtree(gems_dir)
@@ -121,7 +122,7 @@ def generate_gems():
         try:
             os.makedirs(gems_dir)
         except:
-            print("Error creating dir %d , Exiting" % gems_dir)
+            print("Error creating dir %s , Exiting" % gems_dir)
             sys.exit(2)
     print "Compiling required gems.. Please wait."
     command = "%s --showallgems" % install_gems_path

--- a/gem_packages.py
+++ b/gem_packages.py
@@ -20,7 +20,7 @@ from subprocess import Popen, PIPE
 from distutils.version import LooseVersion, StrictVersion
 
 install_gems_path = "/usr/share/one/install_gems"
-gems_dir = 'gems_dir'
+gems_dir = '/var/lib/one/.gem/ruby'
 exclude_gems = []
 
 
@@ -129,7 +129,7 @@ def generate_gems():
     buf = StringIO.StringIO(output)
     for line in buf:
         if not any(exclude_gem in line for exclude_gem in exclude_gems):
-            command = "gem install --no-ri --no-rdoc --install-dir %s %s" % (gems_dir, line)
+            command = "gem install --no-ri --no-rdoc --user-install %s" % (line)
             output = execute_cmd(command)
 
 def generate_packages(pkg,version):


### PR DESCRIPTION
In some cases ruby is not able to check the available gems downloaded in a directory.
Now it was changed the install_gems directory by the user home .gem

Resolves: https://github.com/OpenNebula/addon-installgems/issues/14
See also: http://dev.opennebula.org/issues/4758